### PR TITLE
refactor: 포인트 차감 메소드 통합 및 수정

### DIFF
--- a/src/main/java/cocodas/prier/point/PointTransactionService.java
+++ b/src/main/java/cocodas/prier/point/PointTransactionService.java
@@ -2,8 +2,7 @@ package cocodas.prier.point;
 
 import cocodas.prier.point.dto.PointRechargeRequest;
 import cocodas.prier.point.dto.PointTransactionDTO;
-import cocodas.prier.project.project.Project;
-import cocodas.prier.project.project.ProjectRepository;
+import cocodas.prier.point.dto.PointTransactionMapper;
 import cocodas.prier.user.UserRepository;
 import cocodas.prier.user.Users;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,86 +18,51 @@ public class PointTransactionService {
 
     private final PointTransactionRepository pointTransactionRepository;
     private final UserRepository userRepository;
-    private final ProjectRepository projectRepository;
 
     @Autowired
-    public PointTransactionService(PointTransactionRepository pointTransactionRepository, UserRepository userRepository, ProjectRepository projectRepository) {
+    public PointTransactionService(PointTransactionRepository pointTransactionRepository, UserRepository userRepository) {
         this.pointTransactionRepository = pointTransactionRepository;
         this.userRepository = userRepository;
-        this.projectRepository = projectRepository;
     }
 
     // 현재 포인트 조회
     public Integer getCurrentPoints(Long userId) {
-        Users user = userRepository.findById(userId).orElseThrow();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
         return user.getBalance();
     }
 
     // 포인트 트랜잭션 내역 조회
     public List<PointTransactionDTO> getPointHistory(Long userId) {
         return pointTransactionRepository.findByUsers_UserId(userId).stream()
-                .map(this::convertToDto)
+                .map(PointTransactionMapper::toDto)
                 .collect(Collectors.toList());
     }
 
     // 포인트 충전 (POINT_CHARGE)
     public PointTransactionDTO rechargePoints(PointRechargeRequest request, Long userId) {
-        Users user = userRepository.findById(userId).orElseThrow();
-        PointTransaction transaction = PointTransaction.builder()
-                .amount(request.getAmount())
-                .transactionType(TransactionType.POINT_CHARGE)
-                .createdAt(LocalDateTime.now())
-                .balance(user.getBalance() + request.getAmount())
-                .users(user)
-                .build();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
 
-        user.updateBalance(request.getAmount());
-        userRepository.save(user);
-        pointTransactionRepository.save(transaction);
-
-        return convertToDto(transaction);
+        return processTransaction(user, request.getAmount(), TransactionType.POINT_CHARGE);
     }
 
-
-    // 피드백 기간 연장 (FEEDBACK_EXTENSION)
-    public PointTransactionDTO extendFeedbackPeriod(Long userId, Long projectId, int weeks) {
-        Users user = userRepository.findById(userId).orElseThrow();
-        Project project = projectRepository.findById(projectId).orElseThrow();
-
-        int cost = weeks * 250; // 한 주당 250 포인트 소모로 설정
-        if (user.getBalance() < cost) {
-            throw new IllegalArgumentException("포인트가 부족합니다.");
-        }
-
-        //project.extendFeedbackPeriod(weeks);
-        user.updateBalance(-cost);
-
-        PointTransaction transaction = PointTransaction.builder()
-                .amount(-cost)
-                .transactionType(TransactionType.FEEDBACK_EXTENSION)
-                .createdAt(LocalDateTime.now())
-                .balance(user.getBalance())
-                .users(user)
-                .build();
-
-        userRepository.save(user);
-        projectRepository.save(project);
-        pointTransactionRepository.save(transaction);
-
-        return convertToDto(transaction);
-    }
-
-    // 포인트 차감 (PRODUCT_PURCHASE)
+    // 포인트 차감 (PRODUCT_PURCHASE, FEEDBACK_EXTENSION)
     @Transactional
-    public void deductPointsForPurchase(Users user, Integer amount) {
+    public PointTransactionDTO deductPoints(Users user, Integer amount, TransactionType transactionType) {
         if (user.getBalance() < amount) {
-            throw new IllegalArgumentException("포인트가 부족합니다.");
+            throw new IllegalArgumentException("Insufficient points.");
         }
-        user.updateBalance(-amount);
+
+        return processTransaction(user, -amount, transactionType);
+    }
+
+    private PointTransactionDTO processTransaction(Users user, Integer amount, TransactionType transactionType) {
+        user.updateBalance(amount);
 
         PointTransaction transaction = PointTransaction.builder()
-                .amount(-amount)
-                .transactionType(TransactionType.PRODUCT_PURCHASE)
+                .amount(amount)
+                .transactionType(transactionType)
                 .createdAt(LocalDateTime.now())
                 .balance(user.getBalance())
                 .users(user)
@@ -106,16 +70,7 @@ public class PointTransactionService {
 
         userRepository.save(user);
         pointTransactionRepository.save(transaction);
-    }
 
-    private PointTransactionDTO convertToDto(PointTransaction transaction) {
-        return PointTransactionDTO.builder()
-                .transactionId(transaction.getTransactionId())
-                .amount(transaction.getAmount())
-                .transactionType(transaction.getTransactionType())
-                .createdAt(transaction.getCreatedAt())
-                .balance(transaction.getBalance())
-                .userId(transaction.getUsers().getUserId())
-                .build();
+        return PointTransactionMapper.toDto(transaction);
     }
 }

--- a/src/main/java/cocodas/prier/point/PointTransactionService.java
+++ b/src/main/java/cocodas/prier/point/PointTransactionService.java
@@ -28,7 +28,7 @@ public class PointTransactionService {
     // 현재 포인트 조회
     public Integer getCurrentPoints(Long userId) {
         Users user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저 조회 불가: " + userId));
         return user.getBalance();
     }
 
@@ -42,7 +42,7 @@ public class PointTransactionService {
     // 포인트 충전 (POINT_CHARGE)
     public PointTransactionDTO rechargePoints(PointRechargeRequest request, Long userId) {
         Users user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저 조회 불가: " + userId));
 
         return processTransaction(user, request.getAmount(), TransactionType.POINT_CHARGE);
     }
@@ -51,7 +51,7 @@ public class PointTransactionService {
     @Transactional
     public PointTransactionDTO deductPoints(Users user, Integer amount, TransactionType transactionType) {
         if (user.getBalance() < amount) {
-            throw new IllegalArgumentException("Insufficient points.");
+            throw new IllegalArgumentException("포인트가 부족합니다.");
         }
 
         return processTransaction(user, -amount, transactionType);

--- a/src/main/java/cocodas/prier/point/dto/PointTransactionMapper.java
+++ b/src/main/java/cocodas/prier/point/dto/PointTransactionMapper.java
@@ -3,7 +3,6 @@ package cocodas.prier.point.dto;
 import cocodas.prier.point.PointTransaction;
 import cocodas.prier.point.dto.PointTransactionDTO;
 
-// DTO 변환을 위한 Mapper 클래스
 public class PointTransactionMapper {
 
     public static PointTransactionDTO toDto(PointTransaction transaction) {

--- a/src/main/java/cocodas/prier/point/dto/PointTransactionMapper.java
+++ b/src/main/java/cocodas/prier/point/dto/PointTransactionMapper.java
@@ -1,0 +1,19 @@
+package cocodas.prier.point.dto;
+
+import cocodas.prier.point.PointTransaction;
+import cocodas.prier.point.dto.PointTransactionDTO;
+
+// DTO 변환을 위한 Mapper 클래스
+public class PointTransactionMapper {
+
+    public static PointTransactionDTO toDto(PointTransaction transaction) {
+        return PointTransactionDTO.builder()
+                .transactionId(transaction.getTransactionId())
+                .amount(transaction.getAmount())
+                .transactionType(transaction.getTransactionType())
+                .createdAt(transaction.getCreatedAt())
+                .balance(transaction.getBalance())
+                .userId(transaction.getUsers().getUserId())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
> 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
* 피드백 연장과 포인트 차감 연동을 위한 PointTransactionService 메소드 통합 및 수정

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

1) feedback_extension과 product_purchase로 분리했던 포인트 차감 로직을 deductPoints 하나로 통합하고, PointTransactionService에서는 user 조회를 하지 않도록 수정

2) PointTransactionService에 예외 메시지 추가

3) rechargePoints, deductPoints 메소드의 공통 로직을 processTransaction 메소드로 추출하여 중복 코드 제거

4) PointTransactionService에 있던 DTO 변환 로직을 PointTransactionMapper 클래스로 분리하여 point.dto에 추가

## 📌 PR 진행 시 이러한 점들을 참고해 주세요
* public PointTransactionDTO deductPoints(Users user, Integer amount, TransactionType transactionType) 이렇게 받아와야 합니다!
