### PR TITLE
feat: 포인트 변경 내역 조회 시 tid 함께 반환

### DIFF
--- a/src/main/java/cocodas/prier/point/kakao/KakaoPayService.java
+++ b/src/main/java/cocodas/prier/point/kakao/KakaoPayService.java
@@ -105,7 +105,7 @@ public class KakaoPayService {
 
         log.info("결과: " + payApproveResDto.toString());
 
-        pointTransactionService.increasePoints(user, payApproveResDto.getAmount().getTotal() / 10, TransactionType.POINT_CHARGE);
+        pointTransactionService.increasePoints(user, payApproveResDto.getAmount().getTotal() / 10, TransactionType.POINT_CHARGE, tid);
 
         return payApproveResDto;
     }

--- a/src/main/java/cocodas/prier/point/pointTransaction/PointTransaction.java
+++ b/src/main/java/cocodas/prier/point/pointTransaction/PointTransaction.java
@@ -32,6 +32,9 @@ public class PointTransaction {
     @Column(nullable = false)
     private Integer balance;
 
+    @Column(nullable = true)
+    private String tid;
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "user_id")
     private Users users;

--- a/src/main/java/cocodas/prier/point/pointTransaction/PointTransactionService.java
+++ b/src/main/java/cocodas/prier/point/pointTransaction/PointTransactionService.java
@@ -44,9 +44,9 @@ public class PointTransactionService {
 
     // 포인트 증가
     @Transactional
-    public PointTransactionDTO increasePoints(Users user, Integer amount, TransactionType transactionType) {
+    public PointTransactionDTO increasePoints(Users user, Integer amount, TransactionType transactionType, String tid) {
         logger.info("Increasing points for user {} by {} points", user.getUserId(), amount);
-        PointTransactionDTO result = processTransaction(user, amount, transactionType);
+        PointTransactionDTO result = processTransaction(user, amount, transactionType, tid);
         logger.info("Points increased for user {}: new balance is {}", user.getUserId(), user.getBalance());
         return result;
     }
@@ -59,12 +59,12 @@ public class PointTransactionService {
             throw new IllegalArgumentException("Insufficient points.");
         }
         logger.info("Decreasing points for user {} by {} points", user.getUserId(), amount);
-        PointTransactionDTO result = processTransaction(user, -amount, transactionType);
+        PointTransactionDTO result = processTransaction(user, -amount, transactionType, null);
         logger.info("Points decreased for user {}: new balance is {}", user.getUserId(), user.getBalance());
         return result;
     }
 
-    private PointTransactionDTO processTransaction(Users user, Integer amount, TransactionType transactionType) {
+    private PointTransactionDTO processTransaction(Users user, Integer amount, TransactionType transactionType, String tid) {
         user.updateBalance(amount);
 
         PointTransaction transaction = PointTransaction.builder()
@@ -73,6 +73,7 @@ public class PointTransactionService {
                 .createdAt(LocalDateTime.now())
                 .balance(user.getBalance())
                 .users(user)
+                .tid(tid)
                 .build();
 
         userRepository.save(user);

--- a/src/main/java/cocodas/prier/point/pointTransaction/dto/PointTransactionDTO.java
+++ b/src/main/java/cocodas/prier/point/pointTransaction/dto/PointTransactionDTO.java
@@ -15,4 +15,6 @@ public class PointTransactionDTO {
     private LocalDateTime createdAt;
     private Integer balance;
     private Long userId;
+    private String tid;
 }
+

--- a/src/main/java/cocodas/prier/point/pointTransaction/dto/PointTransactionMapper.java
+++ b/src/main/java/cocodas/prier/point/pointTransaction/dto/PointTransactionMapper.java
@@ -12,6 +12,7 @@ public class PointTransactionMapper {
                 .createdAt(transaction.getCreatedAt())
                 .balance(transaction.getBalance())
                 .userId(transaction.getUsers().getUserId())
+                .tid(transaction.getTid())
                 .build();
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
> 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
* 포인트 카카오페이 충전 환불 처리

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* 포인트 충전 뒤, 환불 처리 시에 tid가 필요하기 때문에 포인트 변동 내역 조회할 때 tid를 함께 보내주어야 한다. 
* KakaoPay에 저장된 tid를 불러와서 PointTransaction에 저장한다. 
* getPointHistory를 하면 tid도 같이 보내진다. 

<img width="841" alt="스크린샷 2024-06-18 오후 5 33 12" src="https://github.com/Coco-Das/PRIER-BE/assets/144209738/7699a812-4739-4058-b993-250294f6deac">

* 이 tid를 가지고 프론트에서 다시 환불할 때 body에 tid를 보내준다. 

<img width="722" alt="스크린샷 2024-06-18 오후 5 34 03" src="https://github.com/Coco-Das/PRIER-BE/assets/144209738/103928c5-3ef7-4952-8d45-3668f2a12713">


## 📌 PR 진행 시 이러한 점들을 참고해 주세요
* 