### PR TITLE
feat: LastLogin 기준으로 피드백 개수 세기 (fixed)

### DIFF
--- a/src/main/java/cocodas/prier/project/feedback/response/ResponseRepository.java
+++ b/src/main/java/cocodas/prier/project/feedback/response/ResponseRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -18,5 +19,15 @@ public interface ResponseRepository extends JpaRepository<Response, Long> {
 
     @Query("SELECT DISTINCT r.question.project.projectId FROM Response r WHERE r.users.userId = :userId")
     List<Long> findDistinctProjectIdsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(DISTINCT r.user.userId) " +
+            "FROM Response r " +
+            "JOIN r.question q " +
+            "JOIN q.project p " +
+            "WHERE p.users.userId = :userId " +
+            "AND r.createdAt > :lastLoginAt")
+    long countFeedbackForUserProjectsAfterLastLogin(@Param("userId") Long userId, @Param("lastLoginAt") LocalDateTime lastLoginAt);
+
+
 }
 

--- a/src/main/java/cocodas/prier/project/feedback/response/ResponseRepository.java
+++ b/src/main/java/cocodas/prier/project/feedback/response/ResponseRepository.java
@@ -20,7 +20,7 @@ public interface ResponseRepository extends JpaRepository<Response, Long> {
     @Query("SELECT DISTINCT r.question.project.projectId FROM Response r WHERE r.users.userId = :userId")
     List<Long> findDistinctProjectIdsByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT COUNT(DISTINCT r.user.userId) " +
+    @Query("SELECT COUNT(DISTINCT p.projectId) " +
             "FROM Response r " +
             "JOIN r.question q " +
             "JOIN q.project p " +

--- a/src/main/java/cocodas/prier/project/feedback/response/ResponseService.java
+++ b/src/main/java/cocodas/prier/project/feedback/response/ResponseService.java
@@ -88,6 +88,13 @@ public class ResponseService {
         return projectIds;
     }
 
+    public long countFeedbackForUserProjectsAfterLastLogin(Long userId) {
+        LocalDateTime lastLoginAt = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid user ID"))
+                .getLastLoginAt();
+        return responseRepository.countFeedbackForUserProjectsAfterLastLogin(userId, lastLoginAt);
+    }
+
     private ResponseDto mapToDto(Response response) {
         return ResponseDto.builder()
                 .responseId(response.getResponseId())


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
> 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
* 로그인 시 알림 만들기
* 쿼리문 수정

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* ResponseService에 countFeedbackForUserProjectsAfterLastLogin 생성

## 📌 PR 진행 시 이러한 점들을 참고해 주세요
* 응답은 질문에 따라서 개수가 세져서 '피드백'을 기준으로 하려면 고민이 좀 필요했다. (한 프로젝트에 질문이 5개면 한 사람이 하나의 피드백을 달았을 때 응답은 5개 -> but  피드백은 1개)
* 피드백으로 응답들을 묶어놓지를 않아서 방법을 고민하다가 아래를 기준으로 했다. 
1) 어차피 리뷰어 기준, 피드백은 한 프로젝트에대해 한 번만 달 것임 **(이 부분 막아놓았나?)**
2) 그래서 한 프로젝트에 대한 응답들에서 userId기준으로 중복 제거하면 피드백 개수가 세짐
3) 사용자의 userId에 해당하는 프로젝트 필터링 -> 2번에서 createdAt > lastLoginAt 까지 필터링